### PR TITLE
chore: bump dependencies to latest stable versions

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -72,7 +72,7 @@ android {
 
 dependencies {
 
-    implementation 'androidx.core:core-ktx:1.16.0'
+    implementation 'androidx.core:core-ktx:1.18.0'
     implementation 'androidx.appcompat:appcompat:1.7.1'
     implementation 'com.google.android.material:material:1.12.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.2.1'
@@ -97,7 +97,7 @@ dependencies {
     implementation 'androidx.activity:activity-ktx:1.10.1'
 
     // viewModel
-    def viewModelVersion = "2.9.2"
+    def viewModelVersion = "2.10.0"
     implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:$viewModelVersion"
     implementation "androidx.lifecycle:lifecycle-livedata-ktx:$viewModelVersion"
 
@@ -109,7 +109,7 @@ dependencies {
     implementation "androidx.browser:browser:1.8.0"
 
     // firebase
-    implementation platform('com.google.firebase:firebase-bom:34.0.0')
+    implementation platform('com.google.firebase:firebase-bom:34.13.0')
     implementation 'com.google.firebase:firebase-crashlytics'
     implementation 'com.google.firebase:firebase-analytics'
     implementation 'com.google.firebase:firebase-perf'
@@ -126,7 +126,7 @@ dependencies {
     implementation("com.google.android.play:review-ktx:2.0.2")
 
     // google adMob
-    implementation 'com.google.android.gms:play-services-ads:24.5.0'
+    implementation 'com.google.android.gms:play-services-ads:24.8.0'
     implementation("com.google.android.ump:user-messaging-platform:3.2.0")
 
     // test

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -39,7 +39,7 @@ android {
     defaultConfig {
         applicationId "com.gigaworks.tech.calculator"
         minSdkVersion 23
-        compileSdk 35
+        compileSdk 36
         targetSdkVersion 35
         versionCode versionProperties['VERSION_CODE'].toInteger()
         versionName "2.6.0"

--- a/build.gradle
+++ b/build.gradle
@@ -10,9 +10,9 @@ buildscript {
         classpath 'com.android.tools.build:gradle:8.11.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "com.google.dagger:hilt-android-gradle-plugin:$hilt_version"
-        classpath 'com.google.gms:google-services:4.4.3'
-        classpath 'com.google.firebase:firebase-crashlytics-gradle:3.0.5'
-        classpath 'com.google.firebase:perf-plugin:2.0.0'
+        classpath 'com.google.gms:google-services:4.4.4'
+        classpath 'com.google.firebase:firebase-crashlytics-gradle:3.0.7'
+        classpath 'com.google.firebase:perf-plugin:2.0.2'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files


### PR DESCRIPTION
## Summary

Safe, non-breaking dependency updates verified against Maven Central and official release notes.

## Changes

### Build plugins ([build.gradle](build.gradle))
| Dependency | Before | After |
|---|---|---|
| google-services | 4.4.3 | 4.4.4 |
| firebase-crashlytics-gradle | 3.0.5 | 3.0.7 |
| firebase perf-plugin | 2.0.0 | 2.0.2 |

### App dependencies ([app/build.gradle](app/build.gradle))
| Dependency | Before | After |
|---|---|---|
| androidx.core:core-ktx | 1.16.0 | 1.18.0 |
| androidx.lifecycle (viewmodel + livedata) | 2.9.2 | 2.10.0 |
| firebase-bom | 34.0.0 | 34.13.0 |
| play-services-ads (AdMob) | 24.5.0 | 24.8.0 |

## What was intentionally skipped

| Dependency | Reason |
|---|---|
| AGP 8.11.1 → 9.x | Major version — requires separate coordinated upgrade with Kotlin + KSP |
| Kotlin 2.1.20 → 2.3.x | Must be coordinated with AGP and KSP version |
| KSP 2.1.20-2.0.1 | Must match Kotlin version exactly |
| UMP 3.2.0 → 4.0.0 | Major version with breaking changes to GDPR consent flow |
| appcompat, material, navigation, constraintlayout | Already at latest stable |
| room, browser, activity-ktx | Already at latest stable or require further validation |
| bigmath, review, taptargetview, junit | Already at latest stable |

## Test plan

- [ ] Sync Gradle — no resolution errors
- [ ] `./gradlew assembleDebug` builds successfully
- [ ] `./gradlew test` — all unit tests pass
- [ ] Launch app on device/emulator — calculator functions correctly
- [ ] Verify AdMob banner loads (or gracefully skips in debug)
- [ ] Verify Firebase Crashlytics and Performance plugins initialize without errors

🤖 Generated with [Claude Code](https://claude.ai/claude-code)