### PR TITLE
build: upgrade AGP 9.2.0 + Kotlin 2.3.21 + KSP 2.3.8

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,10 +10,10 @@
 
 | Tool | Version |
 |---|---|
-| Gradle | 8.11.1 |
-| Kotlin | 2.1.20 |
-| KSP | 2.1.20-2.0.1 |
-| AGP | 8.11.1 |
+| Gradle | 9.4.1 |
+| Kotlin | 2.3.21 |
+| KSP | 2.3.8 |
+| AGP | 9.2.0 |
 | Java compatibility | VERSION_17 |
 
 ### Key Gradle Commands

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,6 +1,5 @@
 plugins {
     id 'com.android.application'
-    id 'kotlin-android'
     id 'dagger.hilt.android.plugin'
     id 'com.google.firebase.crashlytics'
     id 'com.google.firebase.firebase-perf'
@@ -35,6 +34,10 @@ android {
         versionProperties.load(new FileInputStream(versionPropertiesFile))
     }
 
+    kotlin {
+        version = "2.3.21"
+        jvmToolchain(17)
+    }
     namespace 'com.gigaworks.tech.calculator'
     defaultConfig {
         applicationId "com.gigaworks.tech.calculator"
@@ -56,9 +59,6 @@ android {
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_17
         targetCompatibility JavaVersion.VERSION_17
-    }
-    kotlinOptions {
-        jvmTarget = '17'
     }
     buildFeatures {
         viewBinding true

--- a/build.gradle
+++ b/build.gradle
@@ -1,18 +1,16 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
-    ext.kotlin_version = '2.1.20'
-    ext.hilt_version = '2.57'
+    ext.hilt_version = '2.59.2'
     repositories {
         google()
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.11.1'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+        classpath 'com.android.tools.build:gradle:9.2.0'
         classpath "com.google.dagger:hilt-android-gradle-plugin:$hilt_version"
         classpath 'com.google.gms:google-services:4.4.3'
         classpath 'com.google.firebase:firebase-crashlytics-gradle:3.0.5'
-        classpath 'com.google.firebase:perf-plugin:2.0.0'
+        classpath 'com.google.firebase:perf-plugin:2.0.2'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -20,7 +18,7 @@ buildscript {
 }
 
 plugins {
-    id 'com.google.devtools.ksp' version '2.1.20-2.0.1' apply false
+    id 'com.google.devtools.ksp' version '2.3.8' apply false
 }
 
 allprojects {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Sun Dec 24 14:39:11 IST 2023
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## Summary

- **Gradle wrapper** `8.13` → `9.4.1` (minimum required by AGP 9.2)
- **AGP** `8.11.1` → `9.2.0`
- **Kotlin** `2.1.20` → `2.3.21` (pinned via `android { kotlin { version } }` — no longer needs separate KGP classpath)
- **KSP** `2.1.20-2.0.1` → `2.3.8` (KSP adopted independent versioning in 2.x)
- **Hilt** `2.57` → `2.59.2` (2.59+ required for AGP 9 — earlier versions fail with `BaseExtension not found`)
- **Firebase perf-plugin** `2.0.0` → `2.0.2` (fixes AGP 9 `Transform` API removal)

## AGP 9 built-in Kotlin migration

AGP 9.0 ships Kotlin support built in (`android.builtInKotlin=true` is now the default),
making the standalone `kotlin-android` plugin redundant and conflicting. Changes made:

- Removed `id 'kotlin-android'` from `app/build.gradle`
- Removed `classpath "org.jetbrains.kotlin:kotlin-gradle-plugin"` and `ext.kotlin_version` from root `build.gradle`
- Replaced `kotlinOptions { jvmTarget = '17' }` with `kotlin { jvmToolchain(17) }` inside the `android {}` block

## Remaining deprecation warnings (non-blocking, AGP 10 concern)

- `android.nonFinalResIds=false` — deprecated, removed in AGP 10
- `android.enableJetifier=true` — deprecated, removed in AGP 10

## Test plan

- [x] `./gradlew assembleDebug` — BUILD SUCCESSFUL