### PR TITLE
fix: migrate themes to Material3 to fix crash on Android 16

### DIFF
--- a/app/src/main/res/values-night-v27/themes.xml
+++ b/app/src/main/res/values-night-v27/themes.xml
@@ -1,13 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools">
     <!-- Base application theme for API 27+ night mode -->
-    <style name="BaseTheme" parent="Theme.MaterialComponents.DayNight.NoActionBar">
+    <style name="BaseTheme" parent="Theme.Material3.DayNight.NoActionBar">
         <!-- Primary brand color -->
         <item name="colorPrimary">@color/primary</item>
         <item name="colorPrimaryVariant">@color/primaryDark</item>
         <item name="colorOnPrimary">@color/white</item>
         <!-- Color Themes -->
         <item name="colorSurface">@color/surface</item>
+        <item name="colorSurfaceContainer">@color/surface</item>
         <item name="colorError">@color/error</item>
         <item name="android:colorBackground">@color/background</item>
         <item name="colorOnSurface">@color/textPrimary</item>

--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -1,13 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools">
     <!-- Base application theme -->
-    <style name="BaseTheme" parent="Theme.MaterialComponents.DayNight.NoActionBar">
+    <style name="BaseTheme" parent="Theme.Material3.DayNight.NoActionBar">
         <!-- Primary brand color -->
         <item name="colorPrimary">@color/primary</item>
         <item name="colorPrimaryVariant">@color/primaryDark</item>
         <item name="colorOnPrimary">@color/white</item>
         <!-- Color Themes -->
         <item name="colorSurface">@color/surface</item>
+        <item name="colorSurfaceContainer">@color/surface</item>
         <item name="colorError">@color/error</item>
         <item name="android:colorBackground">@color/background</item>
         <item name="colorOnSurface">@color/textPrimary</item>

--- a/app/src/main/res/values-v27/themes.xml
+++ b/app/src/main/res/values-v27/themes.xml
@@ -1,13 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools">
     <!-- Base application theme for API 27+ that supports windowLightNavigationBar -->
-    <style name="BaseTheme" parent="Theme.MaterialComponents.DayNight.NoActionBar">
+    <style name="BaseTheme" parent="Theme.Material3.DayNight.NoActionBar">
         <!-- Primary brand color -->
         <item name="colorPrimary">@color/primary</item>
         <item name="colorPrimaryVariant">@color/primaryDark</item>
         <item name="colorOnPrimary">@color/white</item>
         <!-- Color Themes -->
         <item name="colorSurface">@color/surface</item>
+        <item name="colorSurfaceContainer">@color/surface</item>
         <item name="colorError">@color/error</item>
         <item name="android:colorBackground">@color/background</item>
         <item name="colorOnSurface">@color/textPrimary</item>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,12 +1,13 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
     <!-- Base application theme -->
-    <style name="BaseTheme" parent="Theme.MaterialComponents.DayNight.NoActionBar">
+    <style name="BaseTheme" parent="Theme.Material3.DayNight.NoActionBar">
         <!-- Primary brand color -->
         <item name="colorPrimary">@color/primary</item>
         <item name="colorPrimaryVariant">@color/primaryDark</item>
         <item name="colorOnPrimary">@color/white</item>
         <!-- Color Themes -->
         <item name="colorSurface">@color/surface</item>
+        <item name="colorSurfaceContainer">@color/surface</item>
         <item name="colorError">@color/error</item>
         <item name="android:colorBackground">@color/background</item>
         <item name="colorOnSurface">@color/textPrimary</item>
@@ -71,7 +72,7 @@
     </style>
 
     <!-- Widget Styles -->
-    <style name="Widget.CalculatorPlus.NumPad.Secondary" parent="Widget.MaterialComponents.Button">
+    <style name="Widget.CalculatorPlus.NumPad.Secondary" parent="Widget.Material3.Button">
         <item name="cornerRadius">@dimen/button_corner_radius</item>
         <item name="android:textColor">?attr/colorOnPrimary</item>
         <item name="backgroundTint">?attr/operatorBtnColor</item>
@@ -82,7 +83,7 @@
         <item name="rippleColor">@color/button_ripple_primary</item>
     </style>
 
-    <style name="Widget.CalculatorPlus.NumPad.Primary" parent="Widget.MaterialComponents.Button">
+    <style name="Widget.CalculatorPlus.NumPad.Primary" parent="Widget.Material3.Button">
         <item name="cornerRadius">@dimen/button_corner_radius</item>
         <item name="android:textColor">?attr/textPrimary</item>
         <item name="backgroundTint">?attr/numPadPrimary</item>
@@ -99,14 +100,14 @@
         <item name="android:background">@drawable/button_ripple</item>
     </style>
 
-    <style name="ThemeOverlay.CalculatorPlus.MaterialAlertDialog" parent="ThemeOverlay.MaterialComponents.MaterialAlertDialog">
+    <style name="ThemeOverlay.CalculatorPlus.MaterialAlertDialog" parent="ThemeOverlay.Material3.MaterialAlertDialog">
         <item name="colorPrimary">?attr/operatorBtnColor</item>
         <item name="colorSecondary">?attr/operatorBtnColor</item>
         <item name="colorSurface">@color/background</item>
         <item name="colorOnSurface">@color/textPrimary</item>
     </style>
 
-    <style name="Widget.CalculatorPlus.Switch" parent="Widget.MaterialComponents.CompoundButton.Switch">
+    <style name="Widget.CalculatorPlus.Switch" parent="Widget.Material3.CompoundButton.Switch">
         <item name="materialThemeOverlay">@style/ThemeOverlay.CalculatorPlus.Switch</item>
     </style>
 


### PR DESCRIPTION
## Summary

- **Root cause:** `MaterialToolbar` in `material:1.12.0` requires `colorSurfaceContainer` (a Material3 color token) for its background computation. `Theme.MaterialComponents` (M2) doesn't define this attribute. On Android 16 (API 36), theme attribute resolution is stricter and throws an `InflateException` instead of failing silently.
- Migrates all four `BaseTheme` variants from `Theme.MaterialComponents.DayNight.NoActionBar` → `Theme.Material3.DayNight.NoActionBar`
- Adds `colorSurfaceContainer` mapped to `@color/surface` in each theme so the toolbar background stays visually consistent with the existing design
- Updates widget and overlay style parents to their Material3 equivalents in `values/themes.xml`

## Files changed

| File | Change |
|---|---|
| `values/themes.xml` | M3 parent + widget styles |
| `values-night/themes.xml` | M3 parent |
| `values-v27/themes.xml` | M3 parent |
| `values-night-v27/themes.xml` | M3 parent |

## Reviewer notes

- `TextAppearance.MaterialComponents.*` parent styles in the text appearance definitions are left unchanged — they are library-defined styles that resolve correctly under both M2 and M3.
- `colorPrimaryVariant` is set in the theme but only consumed internally (not referenced by any layout or code file); it's kept for now as M3 maps it to `colorPrimaryContainer` for backward compatibility.
- No logic changes — purely theme/style resource migration.

## Test plan

- [ ] Build debug APK and run on Android 16 (API 36) device/emulator — verify no `InflateException` on launch
- [ ] Verify light and dark themes render correctly with all accent color variants
- [ ] Run `./gradlew test` — all unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)