### PR TITLE
fix: keep @HiltAndroidApp class in R8 to prevent release crash

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -39,3 +39,6 @@
 
 # ── Navigation fragments (instantiated by class name from about_nav_graph.xml) ─
 -keep class com.gigaworks.tech.calculator.ui.about.fragment.** { <init>(); }
+
+# ── Hilt — keep Application class so R8 doesn't break GeneratedComponentManagerHolder instanceof check ─
+-keep @dagger.hilt.android.HiltAndroidApp class * { *; }


### PR DESCRIPTION
## Summary

- Adds a ProGuard keep rule for classes annotated with `@HiltAndroidApp`
- Fixes a crash on app launch in release builds where R8 was breaking Hilt's `GeneratedComponentManagerHolder` instanceof check

## Root Cause

When R8 minification was enabled, it could rename or inline Hilt-generated superclasses. At runtime, `ActivityComponentManager.createComponent()` checks `application instanceof GeneratedComponentManagerHolder` — if Hilt's generated `Hilt_MainApplication` class was affected by R8, this check fails with:

```
IllegalStateException: Hilt Activity must be attached to an @HiltAndroidApp Application.
```

## Fix

Added to `proguard-rules.pro`:
```proguard
-keep @dagger.hilt.android.HiltAndroidApp class * { *; }
```

Closes #72

## Test plan

- [ ] Build a release APK (`./gradlew assembleRelease`) and verify it launches without crashing
- [ ] Run unit tests: `./gradlew test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)